### PR TITLE
feat: save best epoch and modify model save interval

### DIFF
--- a/mmdetection/configs/_base_/datasets/coco_detection.py
+++ b/mmdetection/configs/_base_/datasets/coco_detection.py
@@ -67,4 +67,4 @@ data = dict(
         pipeline=test_pipeline,
     ),
 )
-evaluation = dict(interval=1, metric="bbox")
+evaluation = dict(interval=1, metric="bbox", save_best='bbox_mAP_50')

--- a/mmdetection/tools/train.py
+++ b/mmdetection/tools/train.py
@@ -209,6 +209,10 @@ def main():
     meta['seed'] = seed
     meta['exp_name'] = osp.basename(args.config)
 
+    ########### model save interval ##########
+    cfg.checkpoint_config.interval=6
+    ##########################################
+
     model = build_detector(
         cfg.model,
         train_cfg=cfg.get('train_cfg'),


### PR DESCRIPTION
validation set에서 bbox_mAP_50이 가장 높은 epoch에 대해서 모델을 저장하는 기능을 추가했습니다.

추가적으로 매 epoch마다 저장이 되는 부분은 train.py에서 cfg.checkpoint_config.interval을 수정하여 고치는 기능을 추가했습니다.